### PR TITLE
クエスト参加・取り消し機能の追加

### DIFF
--- a/app/controllers/joins_controller.rb
+++ b/app/controllers/joins_controller.rb
@@ -1,0 +1,18 @@
+class JoinsController < ApplicationController
+  def create
+		quest = Quest.find(params[:quest_id])
+		current_user.join(quest)
+		redirect_back fallback_location: root_path
+	end
+
+	def destroy
+		quest = current_user.joins.find(params[:id]).quest
+		current_user.unjoin(quest)
+		redirect_back fallback_location: root_path
+	end
+
+  # 参加したクエスト一覧を表示するアクション
+  def joins
+    @join_quests = current_user.join_quests.includes(:user).order(created_at: :desc)
+  end
+end

--- a/app/controllers/joins_controller.rb
+++ b/app/controllers/joins_controller.rb
@@ -2,17 +2,12 @@ class JoinsController < ApplicationController
   def create
 		quest = Quest.find(params[:quest_id])
 		current_user.join(quest)
-		redirect_back fallback_location: root_path
+		redirect_back fallback_location: quest
 	end
 
 	def destroy
 		quest = current_user.joins.find(params[:id]).quest
 		current_user.unjoin(quest)
-		redirect_back fallback_location: root_path
+		redirect_back fallback_location: quest
 	end
-
-  # 参加したクエスト一覧を表示するアクション
-  def joins
-    @join_quests = current_user.join_quests.includes(:user).order(created_at: :desc)
-  end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :set_user, only: %i[edit update show]
-  
+
   def edit; end
 
   def update

--- a/app/controllers/quests_controller.rb
+++ b/app/controllers/quests_controller.rb
@@ -36,6 +36,11 @@ class QuestsController < ApplicationController
     end
   end
 
+  # 参加したクエスト一覧を表示するアクション
+  def joins
+    @join_quests = current_user.join_quests.includes(:user).order(created_at: :desc)
+  end
+
   private
 
   def set_quest

--- a/app/controllers/quests_controller.rb
+++ b/app/controllers/quests_controller.rb
@@ -22,6 +22,7 @@ class QuestsController < ApplicationController
 
   def show
     @quest = Quest.find(params[:id])
+    @joins = Join.where(quest_id: @quest.id)
   end
 
   def edit

--- a/app/models/join.rb
+++ b/app/models/join.rb
@@ -1,0 +1,4 @@
+class Join < ApplicationRecord
+  belongs_to :user
+  belongs_to :quest
+end

--- a/app/models/join.rb
+++ b/app/models/join.rb
@@ -1,4 +1,6 @@
 class Join < ApplicationRecord
   belongs_to :user
   belongs_to :quest
+
+  validates :user_id, presence: true, uniqueness: { scope: :quest_id }
 end

--- a/app/models/quest.rb
+++ b/app/models/quest.rb
@@ -1,5 +1,6 @@
 class Quest < ApplicationRecord
   belongs_to :user, dependent: :destroy
+  has_many :joins, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :step, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   has_many :quests, dependent: :destroy
+  has_many :joins, dependent: :destroy
+  has_many :join_quests, through: :joins, source: :quest
 
   authenticates_with_sorcery!
   mount_uploader :avatar, AvatarUploader #カラム名、アップローダー名

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,19 @@ class User < ApplicationRecord
   def own?(object)
     id == object.user_id
   end
+
+  # クエストに参加
+  def join(quest)
+    join_quests << quest
+  end
+
+  # クエスト参加を取り消す
+  def unjoin(quest)
+    join_quests.destroy(quest)
+  end
+
+  # クエスト参加しているか否か判定するメソッド
+  def join?(join)
+    join_quests.include?(quest)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,6 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   mount_uploader :avatar, AvatarUploader #カラム名、アップローダー名
 
-  has_many :quests, dependent: :destroy 
-
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
@@ -32,7 +30,7 @@ class User < ApplicationRecord
   end
 
   # クエスト参加しているか否か判定するメソッド
-  def join?(join)
+  def join?(quest)
     join_quests.include?(quest)
   end
 end

--- a/app/views/quests/_join.html.erb
+++ b/app/views/quests/_join.html.erb
@@ -1,1 +1,1 @@
-<%= link_to '参加する', joins_path(quest_id: quest.id), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded text-lg",  method: :post %>
+<%= link_to '参加する', joins_path(quest_id: quest.id), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded text-lg", data: { "turbo-method": :post } %>

--- a/app/views/quests/_join.html.erb
+++ b/app/views/quests/_join.html.erb
@@ -1,0 +1,1 @@
+<%= link_to '参加する', joins_path(quest_id: quest.id), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded text-lg",  method: :post %>

--- a/app/views/quests/_join_button.html.erb
+++ b/app/views/quests/_join_button.html.erb
@@ -1,0 +1,5 @@
+<% if current_user.join?(quest) %>
+	<%= render 'unjoin', quest: quest %>
+<% else %>
+	<%= render 'join', quest: quest %>
+<% end %>

--- a/app/views/quests/_unjoin.html.erb
+++ b/app/views/quests/_unjoin.html.erb
@@ -1,1 +1,1 @@
-<%= link_to '参加を取り消す', join_path(current_user.joins.find_by(quest_id: quest.id)), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded text-lg",  method: :delete %>
+<%= link_to '参加を取り消す', join_path(current_user.joins.find_by(quest_id: quest.id)), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded text-lg",  data: { "turbo-method": :delete } %>

--- a/app/views/quests/_unjoin.html.erb
+++ b/app/views/quests/_unjoin.html.erb
@@ -1,0 +1,1 @@
+<%= link_to '参加を取り消す', join_path(current_user.joins.find_by(quest_id: quest.id)), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded text-lg",  method: :delete %>

--- a/app/views/quests/joins.html.erb
+++ b/app/views/quests/joins.html.erb
@@ -1,0 +1,11 @@
+<section class="text-gray-600 body-font">
+  <div class="container px-5 py-24 mx-auto">
+    <div class="flex flex-wrap -m-4">
+			<% if @join_quests.present? %>
+				<%= render @join_quests %>
+			<% else %>
+				<p><%= t('.no_result') %></p>
+			<% end %>
+    </div>
+  </div>
+</section>

--- a/app/views/quests/show.html.erb
+++ b/app/views/quests/show.html.erb
@@ -32,7 +32,7 @@
   </div>
 
   <br>
-  <h1 class="flex justify-center font-bold text-4xl">クエスト参加者</h1>
+  <h1 class="flex justify-center font-bold text-4xl"><%= t('.joins') %></h1>
   <section class="text-gray-600 body-font">
     <div class="container px-5 py-24 mx-auto">
       <div class="flex flex-wrap -m-4">
@@ -40,13 +40,13 @@
           <% @joins.each do |join| %>
             <div class="p-4 drop-shadow-2xl">
               <div class="h-full bg-opacity-75 px-8 pt-16 pb-24 rounded-lg overflow-hidden text-center relative" style="background-image: url('<%= asset_path('quest.png') %>'); background-repeat: no-repeat; background-position: center; background-size: contain;">
-                <h1 class="title-font sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg">ハンター名</h1>
+                <h1 class="title-font sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg"><%= t('.hunter_name') %></h1>
                 <h3 class="title-font sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg"><%= join.user.name %></h3>
               </div>
             </div>
           <% end %>
         <% else %>
-          <p>現在参加希望中のハンターはいません</p>
+          <p><%= t('.no_joins') %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/quests/show.html.erb
+++ b/app/views/quests/show.html.erb
@@ -30,5 +30,20 @@
     <h3><%= Quest.human_attribute_name(:body) %></h3>
     <p class="block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full"><%= @quest.body %></p>
   </div>
+
+  <br>
+  <h1 class="flex justify-center font-bold text-4xl">クエスト参加者</h1>
+  <% if @joins.present? %>
+    <% @joins.each do |join| %>
+      <div class="p-4 drop-shadow-2xl">
+        <div class="h-full bg-opacity-75 px-8 pt-16 pb-24 rounded-lg overflow-hidden text-center relative" style="background-image: url('<%= asset_path('quest.png') %>'); background-repeat: no-repeat; background-position: center; background-size: contain;">
+          <h1 class="title-font sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg">ハンター名</h1>
+          <h3 class="title-font sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg"><%= join.user.name %></h3>
+        </div>
+      </div>
+    <% end %>
+  <% else %>
+    <p>現在参加希望中のハンターはいません</p>
+  <% end %>
 </div>
 

--- a/app/views/quests/show.html.erb
+++ b/app/views/quests/show.html.erb
@@ -6,7 +6,11 @@
     <br>
     <h1 class="flex justify-center font-bold text-4xl"><%= @quest.title %></h1>
   </div>
-  <%= render 'edit_button', quest: @quest if current_user.own?(@quest) %>
+  <% if current_user.own?(@quest) %>
+    <%= render 'edit_button', quest: @quest %>
+  <% else %>
+    <%= render 'join_button', quest: @quest %>
+  <% end %>
   <br>
   <div class="my-5">
     <h3><%= Quest.human_attribute_name(:date_time) %></h3>

--- a/app/views/quests/show.html.erb
+++ b/app/views/quests/show.html.erb
@@ -33,17 +33,23 @@
 
   <br>
   <h1 class="flex justify-center font-bold text-4xl">クエスト参加者</h1>
-  <% if @joins.present? %>
-    <% @joins.each do |join| %>
-      <div class="p-4 drop-shadow-2xl">
-        <div class="h-full bg-opacity-75 px-8 pt-16 pb-24 rounded-lg overflow-hidden text-center relative" style="background-image: url('<%= asset_path('quest.png') %>'); background-repeat: no-repeat; background-position: center; background-size: contain;">
-          <h1 class="title-font sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg">ハンター名</h1>
-          <h3 class="title-font sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg"><%= join.user.name %></h3>
-        </div>
+  <section class="text-gray-600 body-font">
+    <div class="container px-5 py-24 mx-auto">
+      <div class="flex flex-wrap -m-4">
+        <% if @joins.present? %>
+          <% @joins.each do |join| %>
+            <div class="p-4 drop-shadow-2xl">
+              <div class="h-full bg-opacity-75 px-8 pt-16 pb-24 rounded-lg overflow-hidden text-center relative" style="background-image: url('<%= asset_path('quest.png') %>'); background-repeat: no-repeat; background-position: center; background-size: contain;">
+                <h1 class="title-font sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg">ハンター名</h1>
+                <h3 class="title-font sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg"><%= join.user.name %></h3>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <p>現在参加希望中のハンターはいません</p>
+        <% end %>
       </div>
-    <% end %>
-  <% else %>
-    <p>現在参加希望中のハンターはいません</p>
-  <% end %>
+    </div>
+  </section>
 </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,6 +6,7 @@
     <nav class="md:ml-auto flex flex-wrap items-center text-base justify-center">
       <%= link_to t('quests.index.title'), quests_path, class: 'mr-5 hover:text-gray-400' %>
       <%= link_to t('quests.new.title'), new_quest_path, class: 'mr-5 hover:text-gray-400' %>
+      <%= link_to '参加したクエスト', joins_quests_path, class: 'mr-5 hover:text-gray-400' %>
       <%= link_to t('プロフィール'), profile_path, class: 'mr-5 hover:text-gray-400' %>
     </nav>
     <%= button_to logout_path, method: :delete do %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,8 +6,8 @@
     <nav class="md:ml-auto flex flex-wrap items-center text-base justify-center">
       <%= link_to t('quests.index.title'), quests_path, class: 'mr-5 hover:text-gray-400' %>
       <%= link_to t('quests.new.title'), new_quest_path, class: 'mr-5 hover:text-gray-400' %>
-      <%= link_to '参加したクエスト', joins_quests_path, class: 'mr-5 hover:text-gray-400' %>
-      <%= link_to t('プロフィール'), profile_path, class: 'mr-5 hover:text-gray-400' %>
+      <%= link_to t('quests.joins.title'), joins_quests_path, class: 'mr-5 hover:text-gray-400' %>
+      <%= link_to t('profiles.show.title'), profile_path, class: 'mr-5 hover:text-gray-400' %>
     </nav>
     <%= button_to logout_path, method: :delete do %>
       <button class="inline-flex items-center bg-gray-800 border-0 py-1 px-3 focus:outline-none hover:bg-gray-500 rounded text-base mt-4 md:mt-0"><%= t('defaults.logout') %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,8 +25,13 @@ ja:
     show:
       title: 'クエスト詳細'
       unknown_date_time: '開催日未定'
+      joins: 'クエスト参加者'
+      no_joins: '現在参加希望中のハンターはいません'
+      hunter_name: 'ハンター名'
     edit:
       title: '編集'
+    joins:
+      title: '参加クエスト'
   users:
     new:
       title:  'ハンター登録'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,12 @@ Rails.application.routes.draw do
   delete 'logout' => 'user_sessions#destroy', :as => :logout
 
   resources :users
-  resources :quests, only: %i[index new create show edit update]
+  resources :quests, only: %i[index new create show edit update] do
+    collection do
+      get 'joins'
+    end
+  end
   resources :password_resets, only: %i[new create edit update]
   resource :profile, only: %i[show edit update]
+  resources :joins, only: %i[create destroy]
 end

--- a/db/migrate/20230330074508_create_joins.rb
+++ b/db/migrate/20230330074508_create_joins.rb
@@ -1,0 +1,11 @@
+class CreateJoins < ActiveRecord::Migration[7.0]
+  def change
+    create_table :joins do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :quest, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :joins, [:user_id, :quest_id], unique: :true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_25_041831) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_30_074508) do
+  create_table "joins", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "quest_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["quest_id"], name: "index_joins_on_quest_id"
+    t.index ["user_id", "quest_id"], name: "index_joins_on_user_id_and_quest_id", unique: true
+    t.index ["user_id"], name: "index_joins_on_user_id"
+  end
+
   create_table "quests", charset: "utf8mb4", force: :cascade do |t|
     t.string "title", null: false
     t.datetime "date_time"
@@ -39,5 +49,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_25_041831) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
+  add_foreign_key "joins", "quests"
+  add_foreign_key "joins", "users"
   add_foreign_key "quests", "users"
 end


### PR DESCRIPTION
# 概要
クエスト参加・取り消し機能を作成しました！ #19 
確認お願いします🙏
# 詳細
- Join(クエスト参加)のMVCを作成
- クエスト詳細画面にクエスト参加ボタン、並びに参加取り消しボタンを追加（参加中か否かで処理が分岐するよう実装済み）
- クエスト詳細画面の下部にクエスト参加者リストを表示
- ヘッダーに自身の参加したクエストが表示される「参加クエスト」リンクを作成
# 懸念点ほか
- デザインテキトーです！(いつもの)
- 予定だと本リリースまでにコメントカラムも追加としているが、どう実装すべきか(テーブルを新しく作ってjoinsテーブルと切り離しでもいい気もする)
- 参加者リストは仮にハンター名だけ表示しているが、他に表示するカラムがあった方がいい...？(ランクとか表示できればいいのかな...？モンハンやったことないからよくわからん)


# 以下、スクショになります！

参加クエストページ↓
<img width="1433" alt="1" src="https://user-images.githubusercontent.com/113349377/228819800-109a0c34-2247-4928-9703-95729dcb44ec.png">

クエスト詳細ページ↓
<img width="1310" alt="2" src="https://user-images.githubusercontent.com/113349377/228819925-2ef1ddc8-1ffc-4c7d-ae21-16a261d9cef0.png">
