### PR TITLE
View revise

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.3"
+ruby "3.1.4"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.4", ">= 7.0.4.3"

--- a/app/controllers/joins_controller.rb
+++ b/app/controllers/joins_controller.rb
@@ -2,12 +2,12 @@ class JoinsController < ApplicationController
   def create
 		quest = Quest.find(params[:quest_id])
 		current_user.join(quest)
-		redirect_back fallback_location: quest
+		redirect_to quests_path
 	end
 
 	def destroy
 		quest = current_user.joins.find(params[:id]).quest
 		current_user.unjoin(quest)
-		redirect_back fallback_location: quest
+		redirect_to quests_path
 	end
 end

--- a/app/controllers/quests_controller.rb
+++ b/app/controllers/quests_controller.rb
@@ -32,9 +32,9 @@ class QuestsController < ApplicationController
 
   def update
     if @quest.update(quest_params)
-      redirect_to @quest
+      redirect_to quests_path
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/models/quest.rb
+++ b/app/models/quest.rb
@@ -2,7 +2,7 @@ class Quest < ApplicationRecord
   belongs_to :user
   has_many :joins, dependent: :destroy
 
-  validates :title, presence: true, length: { maximum: 255 }
+  validates :title, presence: true, length: { maximum: 8 }
   validates :step, presence: true
   validates :body, presence: true, length: { maximum: 65535 }
   validates :place, presence: true, length: { maximum: 255 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,8 +18,8 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
     <%= render 'shared/flash_message' %>
-    <main class="flex w-full bg-opacity-75" style="background-image: url('<%= asset_path('bgimg6.jpeg') %>'); background-repeat: no-repeat; background-position: center; background-size: cover;">
-        <%= yield %>
+    <main class="flex w-full" style="background-image: url('<%= asset_path('bgimg6.jpeg') %>'); background-repeat: no-repeat; background-position: center; background-size: cover;">
+      <%= yield %>
     </main>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/profiles/_user.html.erb
+++ b/app/views/profiles/_user.html.erb
@@ -1,13 +1,13 @@
-<section class="text-slate-100 body-font">
-  <div class="container px-5 py-24 mx-auto flex flex-col">
+<section class="body-font">
+  <div class="container px-5 flex flex-col">
     <div class="lg:w-4/6 mx-auto">
       <div class="flex flex-col sm:flex-row mt-10">
         <div class="sm:w-1/3 text-center sm:pr-8 sm:py-8">
-          <div class="w-30 h-30 rounded-full inline-flex items-center justify-center bg-gray-200 text-gray-400">
+          <div class="w-30 h-30 rounded-full inline-flex items-center justify-center bg-gray-200">
             <%= image_tag current_user.avatar.url, class: 'w-30 h-30 rounded-full' %>
           </div>
           <div class="flex flex-col items-center text-center justify-center">
-            <h2 class="font-medium title-font mt-4 text-slate-100 text-lg"><%= user.name %></h2>
+            <h2 class="font-medium title-font mt-4 text-lg"><%= user.name %></h2>
             <div class="w-12 h-1 bg-green-500 rounded mt-2 mb-4"></div>
             <p class="text-base"></p>
           </div>
@@ -16,7 +16,7 @@
           <p class="leading-relaxed text-lg mb-4"><%= User.human_attribute_name(:email) %><%= user.email %></p>
         </div>
       </div>
-      <div class="rounded-lg h-64 overflow-hidden">
+      <div class="rounded-lg overflow-hidden">
         <%= link_to t('profiles.show.edit'), edit_profile_path, class: "text-white bg-green-500 border-0 py-2 px-6 focus:outline-none hover:bg-green-600 rounded mt-2 rounded-lg py-3 px-5 inline-block items-center justify-center" %>
       </div>
     </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,4 +1,5 @@
-<div class="mx-auto md:w-2/3 w-full">
+<div class="max-w-lg mx-auto my-10 bg-white p-8 rounded-xl shadow shadow-slate-300">
+  <h1 class="font-bold text-3xl"><%= t '.title' %></h1>
   <%= render "form", user: @user %>
   <%= link_to t('profiles.edit.show'), profile_path(current_user), class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,3 +1,4 @@
-<div class="mx-auto">
+<div class="max-w-lg mx-auto my-10 bg-white p-8 rounded-xl shadow shadow-slate-300">
+  <h1 class="font-bold text-4xl"><%= t '.title' %></h1>
   <%= render "user", user: @user %>
 </div>

--- a/app/views/quests/_edit_button.html.erb
+++ b/app/views/quests/_edit_button.html.erb
@@ -1,1 +1,1 @@
-<%= link_to t('quests.edit.title'), edit_quest_path(quest), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded text-lg" if current_user.own?(quest) %>
+<%= link_to t('quests.edit.title'), edit_quest_path(quest), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded" if current_user.own?(quest) %>

--- a/app/views/quests/_edit_button.html.erb
+++ b/app/views/quests/_edit_button.html.erb
@@ -1,1 +1,1 @@
-<%= link_to t('quests.edit.title'), edit_quest_path(quest), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded" if current_user.own?(quest) %>
+<%= link_to t('quests.edit.title'), edit_quest_path(quest), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-3 focus:outline-none hover:bg-lime-500 rounded" if current_user.own?(quest) %>

--- a/app/views/quests/_form.html.erb
+++ b/app/views/quests/_form.html.erb
@@ -1,25 +1,25 @@
-<%= form_with model: quest, local: true do |f| %>
+<%= form_with model: quest do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
 
   <div class="my-5 ml-5 mr-4">
-    <%= f.label :title, class:"text-slate-100" %>
-    <%= f.text_field :title, class: "block shadow rounded-md mr-4 text-current border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= f.label :title %>
+    <%= f.text_field :title, placeholder: "8文字以内" ,class: "block shadow rounded-md mr-4 text-current border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
   <div class="my-5 ml-5 mr-4">
-    <%= f.label :step, class:"text-slate-100" %>
+    <%= f.label :step %>
     <br>
     <%= f.select :step, Quest.steps.keys.map { |k| [I18n.t("enums.quest.step.#{k}"), k]}, class:"text-current" %>
   </div>
   <div class="my-5 ml-5 mr-4">
-    <%= f.label :date_time, class:"text-slate-100" %>
+    <%= f.label :date_time %>
     <%= f.datetime_field :date_time, class: "block shadow rounded-md border text-current border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
   <div class="my-5 ml-5 mr-4">
-    <%= f.label :place, class:"text-slate-100" %>
+    <%= f.label :place %>
     <%= f.text_field :place, class: "block shadow rounded-md border border-gray-200 text-current outline-none px-3 py-2 mt-2 w-full" %>
   </div>
   <div class="my-5 ml-5 mr-4">
-    <%= f.label :body, class:"text-slate-100" %>
+    <%= f.label :body %>
     <%= f.text_area :body, class: "block shadow rounded-md border text-current border-gray-200 outline-none px-3 py-2 mt-2 w-full", rows: 10 %>
   </div>
     <%= f.submit t('quests.new.create_quest'), class: "ml-5 mb-8 inline-flex text-white bg-green-500 border-0 py-2 px-6 focus:outline-none hover:bg-green-600 rounded text-lg" %>

--- a/app/views/quests/_join.html.erb
+++ b/app/views/quests/_join.html.erb
@@ -1,1 +1,1 @@
-<%= link_to '参加する', joins_path(quest_id: quest.id), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded text-lg", data: { "turbo-method": :post } %>
+<%= link_to '参加', joins_path(quest_id: quest.id), class: "inline-flex text-white bg-blue-400 border-0 py-2 px-3 focus:outline-none hover:bg-blue-300 rounded", data: { "turbo-method": :post } %>

--- a/app/views/quests/_quest.html.erb
+++ b/app/views/quests/_quest.html.erb
@@ -2,7 +2,7 @@
         <% if quest.state == 'completed' %>
           <%= image_tag 'quest_clear.png', class: "quest_clear_image", alt: "hero" %>
         <% end %>
-        <div class="h-full bg-opacity-75 px-8 pt-16 pb-24 rounded-lg overflow-hidden text-center relative" style="background-image: url('<%= asset_path('quest.png') %>'); background-repeat: no-repeat; background-position: center; background-size: contain;">
+        <div class="h-full bg-opacity-75 px-8 pt-16 pb-16 rounded-lg overflow-hidden text-center relative" style="background-image: url('<%= asset_path('quest.png') %>'); background-repeat: no-repeat; background-position: center; background-size: contain;">
             <h2 class="sm:text-2xl text-base text-current mt-4 mb-3 drop-shadow-lg"><%= quest.title %></h2>
             <h2 class="tracking-widest text-sm title-font font-medium text-slate-500 mb-1">
               <% if quest.date_time.present? %>
@@ -12,7 +12,13 @@
               <% end %>
             </h2>
             <p class="leading-relaxed mb-3 text-sm text-slate-500"><%= t('quests.index.place') %><%= quest.place %></p>
-            <a><%= link_to t('quests.index.view_details'), quest_path(quest), class: 'text-lime-700 inline-flex items-center' %></a>
-            <%= render 'edit_button', quest: quest if current_user.own?(quest) && quest.state == 'not_completed' %>
+            <% if quest.state == "not_completed" %>
+              <%= link_to t('quests.index.view_details'), quest_path(quest), class: "inline-flex text-white bg-gray-400 border-0 py-2 px-3 focus:outline-none hover:bg-gray-300 rounded" %>
+            <% end %>
+            <% if current_user.own?(quest) && quest.state == "not_completed" %>
+              <%= render 'edit_button', quest: quest %>
+            <% else %>
+              <%= render 'join_button', quest: quest if quest.state == 'not_completed' %>
+            <% end %>
         </div>
       </div>

--- a/app/views/quests/_quest.html.erb
+++ b/app/views/quests/_quest.html.erb
@@ -3,7 +3,7 @@
           <%= image_tag 'quest_clear.png', class: "quest_clear_image", alt: "hero" %>
         <% end %>
         <div class="h-full bg-opacity-75 px-8 pt-16 pb-24 rounded-lg overflow-hidden text-center relative" style="background-image: url('<%= asset_path('quest.png') %>'); background-repeat: no-repeat; background-position: center; background-size: contain;">
-            <h1 class="title-font sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg"><%= quest.title %></h1>
+            <h2 class="sm:text-2xl text-base text-current mt-4 mb-3 drop-shadow-lg"><%= quest.title %></h2>
             <h2 class="tracking-widest text-sm title-font font-medium text-slate-500 mb-1">
               <% if quest.date_time.present? %>
                 <%= "#{Quest.human_attribute_name(:date_time)}: #{quest.date_time&.strftime("%m-%d %H:%M")}" %>

--- a/app/views/quests/_unjoin.html.erb
+++ b/app/views/quests/_unjoin.html.erb
@@ -1,1 +1,1 @@
-<%= link_to '参加を取り消す', join_path(current_user.joins.find_by(quest_id: quest.id)), class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded text-lg",  data: { "turbo-method": :delete } %>
+<%= link_to '不参加', join_path(current_user.joins.find_by(quest_id: quest.id)), class: "inline-flex text-white bg-red-400 border-0 py-2 px-3 focus:outline-none hover:bg-red-300 rounded",  data: { "turbo-method": :delete } %>

--- a/app/views/quests/edit.html.erb
+++ b/app/views/quests/edit.html.erb
@@ -1,7 +1,5 @@
-<body class="antialiased bg-slate-200">
-  <div class="max-w-lg mx-auto my-10 bg-white p-8 rounded-xl shadow shadow-slate-600">
+<div class="max-w-lg mx-auto my-10 bg-white p-8 rounded-xl shadow shadow-slate-300">
   <h1 class="font-bold text-4xl mt-10"><%= t('.title') %></h1>
 
   <%= render 'quests/form', { quest: @quest } %>
 </div>
-</body>

--- a/app/views/quests/edit.html.erb
+++ b/app/views/quests/edit.html.erb
@@ -1,5 +1,7 @@
-<div class="mx-auto md:w-2/3 w-full mb-8 text-slate-50 bg-neutral-300 bg-opacity-25">
+<body class="antialiased bg-slate-200">
+  <div class="max-w-lg mx-auto my-10 bg-white p-8 rounded-xl shadow shadow-slate-600">
   <h1 class="font-bold text-4xl mt-10"><%= t('.title') %></h1>
 
   <%= render 'quests/form', { quest: @quest } %>
 </div>
+</body>

--- a/app/views/quests/new.html.erb
+++ b/app/views/quests/new.html.erb
@@ -1,5 +1,8 @@
-<div class="mx-auto md:w-2/3 w-full mb-8 bg-neutral-300 bg-opacity-25">
-  <h1 class="font-bold text-4xl ml-5 mt-10 text-slate-100"><%= t('.title') %></h1>
+<body class="antialiased bg-slate-200">
+  <div class="max-w-lg mx-auto my-10 bg-white p-8 rounded-xl shadow shadow-slate-300">
+  <h1 class="font-bold text-4xl ml-5 mt-10"><%= t('.title') %></h1>
 
   <%= render 'quests/form', { quest: @quest } %>
 </div>
+</div>
+</body>

--- a/app/views/quests/show.html.erb
+++ b/app/views/quests/show.html.erb
@@ -1,13 +1,10 @@
-<div class="mx-auto md:w-2/3 w-full mb-8">
+<div class="mx-auto md:w-2/3 w-full mb-8 bg-white p-5 mt-8">
         <% if @quest.state == 'completed' %>
           <%= image_tag 'quest_clear.png', class: "quest_clear_image_show", alt: "hero" %>
         <% end %>
-  <h1 class="font-bold text-4xl"><%= t('.title') %></h1>
   <br>
   <div class="my-5">
-    <h1 class="flex justify-center font-bold text-4xl"><%= Quest.human_attribute_name(:title) %></h1>
-    <br>
-    <h1 class="flex justify-center font-bold text-4xl"><%= @quest.title %></h1>
+    <h1 class="flex justify-center font-bold text-4xl">「<%= @quest.title %>」の討伐</h1>
   </div>
   <% if current_user.own?(@quest) && @quest.state == 'not_completed' %>
     <%= render 'edit_button', quest: @quest %>
@@ -59,4 +56,4 @@
     <%= button_to 'クエストを完了する', toggle_state_quest_path(@quest), method: :patch, class: "inline-flex text-white bg-lime-600 border-0 py-2 px-6 focus:outline-none hover:bg-lime-500 rounded text-lg", data: { turbo_method: "get", turbo_confirm: t('.completed?') } %>
   <% end %>
 </div>
-
+</div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,11 +1,8 @@
 <header class="text-gray-100 body-font bg-neutral-900">
   <div class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
-    <%= link_to quests_path do %>
-      <span>hunter</span>
-    <% end %>
+    <%= link_to "Code Hunter", root_path, class: 'mr-5' %>
     <nav class="md:ml-auto flex flex-wrap items-center text-base justify-center">
-      <%= link_to t('quests.index.title'), quests_path, class: 'mr-5 hover:text-gray-900' %>
-      <%= link_to t('defaults.signup'), new_user_path, class: 'mr-5 hover:text-gray-900' %>
+      <%= link_to t('defaults.signup'), new_user_path, class: 'mr-5 hover:bg-gray-500' %>
     </nav>
     <%= link_to login_path do %>
       <button class="inline-flex items-center bg-gray-800 border-0 py-1 px-3 focus:outline-none hover:bg-gray-500 rounded text-base mt-4 md:mt-0"><%= t('defaults.login') %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,8 +1,6 @@
 <header class="text-gray-100 body-font bg-neutral-900">
   <div class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
-    <a class="flex title-font font-medium items-center text-gray-100 mb-4 md:mb-0">
-      <span class="ml-3 text-xl">hunter</span>
-    </a>
+    <%= link_to "Code Hunter", quests_path, class: 'mr-5' %>
     <nav class="md:ml-auto flex flex-wrap items-center text-base justify-center">
       <%= link_to t('quests.index.title'), quests_path, class: 'mr-5 hover:text-gray-400' %>
       <%= link_to t('quests.new.title'), new_quest_path, class: 'mr-5 hover:text-gray-400' %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,12 +1,18 @@
-<section class="text-gray-100 body-font">
+<section class="body-font">
   <div class="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
-    <div class="lg:max-w-lg lg:w-full md:w-1/2 w-5/6 mb-10 md:mb-0">
+    <%
+=begin%>
+ <div class="lg:max-w-lg lg:w-full md:w-1/2 w-5/6 mb-10 md:mb-0">
       <%= image_tag 'top.jpeg', class: "object-cover object-center rounded", alt: "hero" %>
-    </div>
-    <div class="lg:flex-grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center">
-      <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-100">Hunter
+    </div> 
+<%
+=end%>
+    <div class="lg:flex-grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center mt-10 mb-10">
+      <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium">Code Hunter
       </h1>
-      <p class="mb-8 leading-relaxed">Let's go hunting</p>
+      <div>
+        <h2 class="mb-8 sm:text-2xl text-1xl leading-relaxed">- ともに困難を乗り越えよう -</h2>
+      </div>
       <div class="flex justify-center">
         <%= link_to 'ログイン', login_path, class: "inline-flex text-white bg-green-500 border-0 py-2 px-6 focus:outline-none hover:bg-green-600 rounded text-lg" %>
         <%= link_to '新規登録', new_user_path, class: "ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg" %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,10 +1,12 @@
-<div class="mx-auto md:w-2/3 w-full mb-8 mt-8 text-gray-800">
-  <h1 class="font-bold text-4xl"><%= t '.title' %></h1>
+<body class="antialiased bg-slate-200">
+  <div class="max-w-lg mx-auto my-10 bg-white p-8 rounded-xl shadow shadow-slate-300">
+    <h1 class="font-bold text-4xl"><%= t '.title' %></h1>
 
-  <%= render "form" %>
-  <br>
-  <br>
+    <%= render "form" %>
+    <br>
+    <br>
 
-  <%= link_to (t '.password_forget'), new_password_reset_path, class:"font-medium text-orange-600 dark:text-blue-500 hover:underline" %>
-  <%= link_to (t '.to_register_page'), new_user_path, class:"ml-4 inline-flex text-orange-700 bg-orange-100 border-0 py-2 px-6 focus:outline-none hover:bg-orange-200 rounded text-lg" %>
-</div>
+    <%= link_to (t '.password_forget'), new_password_reset_path, class:"ml-4 inline-flex bg-orange-100 border-0 py-2 px-6 focus:outline-none hover:bg-orange-200 rounded text-lg mb-3" %>
+    <%= link_to (t '.to_register_page'), new_user_path, class:"ml-4 inline-flex bg-orange-100 border-0 py-2 px-6 focus:outline-none hover:bg-orange-200 rounded text-lg" %>
+  </div>
+</body>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
-<div class="mx-auto md:w-2/3 w-full mb-8">
-  <h1 class="font-bold text-4xl"><%= t '.title' %></h1>
-
-  <%= render "form", user: @user %>
-
-  <%= link_to (t '.to_login_page'), login_path, class: "ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg" %>
-</div>
+<body class="antialiased bg-slate-200">
+  <div class="max-w-lg mx-auto my-10 bg-white p-8 rounded-xl shadow shadow-slate-300">
+    <h1 class="font-bold text-4xl"><%= t '.title' %></h1>
+    <%= render "form", user: @user %>
+    <%= link_to (t '.to_login_page'), login_path, class: "ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg" %>
+  </div>
+</body>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -23,3 +23,6 @@ ja:
         basic: '基礎STEP'
         advanced: '応用STEP'
         other: 'その他'
+      state:
+        not_completed: '未完了'
+        completed: '完了済み'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -15,7 +15,7 @@ ja:
       no_result: 'クエストがありません'
       datetime_no_result: '開催時間： 未定'
       place: '開催場所： '
-      view_details: '詳細を見る'
+      view_details: '詳細'
     new:
       title: 'クエスト依頼'
       create_quest: 'クエストを依頼'


### PR DESCRIPTION
見た目修正（途中）
- 共通部分
ヘッダーの修正

- ログイン前
TOP、ログイン、ユーザー作成画面の修正

- ログイン後
クエスト一覧、詳細、作成、編集画面の修正
プロフィール詳細、編集画面の修正
クエストのタイトルを8文字以内のバリデーション追加し、一覧での見え方修正

<img width="1264" alt="スクリーンショット 2023-04-02 14 37 49" src="https://user-images.githubusercontent.com/102893104/229339316-df0c0473-4d8a-4c7a-af7e-0993bee13bfa.png">

