### PR TITLE
メタタグの設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,4 +82,4 @@ end
 
 gem 'sorcery'
 gem 'config'
-
+gem 'meta-tags'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,8 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    meta-tags (2.18.0)
+      actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
@@ -346,6 +348,7 @@ DEPENDENCIES
   foreman
   importmap-rails
   letter_opener_web
+  meta-tags
   mysql2 (~> 0.5)
   pry-byebug
   puma (~> 5.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,4 +4,34 @@ module ApplicationHelper
 
     page_title.empty? ? base_title : page_title + ' | ' + base_title
   end
+
+  def default_meta_tags
+    {
+      site: 'Code Hunter',
+      title: 'Code Hunter',
+      reverse: true,
+      charset: 'utf-8',
+      description: 'Code Hunterは、ユーザーが課題の手助け(討伐)を気楽に募集、参加できる集会所(掲示板アプリ)です。',
+      keywords: 'codehunter',
+      canonical: request.original_url,
+      separator: '|',
+      # icon: [
+      #   { href: image_url('favicon.ico') },
+      #   { href: image_url('icon.jpg'), rel: 'apple-touch-icon', sizes: '180x180', type: 'image/jpg' },
+      # ],
+      og: {
+        site_name: :site,
+        title: :title,
+        description: :description,
+        type: 'website',
+        url: request.original_url,
+        image: image_url('logo.png'),
+        locale: 'ja_JP',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        site:,
+      }
+    }
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,8 @@
   <head>
     <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+
+    <%= display_meta_tags(default_meta_tags) %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  # config.keywords_lowercase = true
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end


### PR DESCRIPTION
# 概要
Twitterカードの表示とSEOのため、メタタグの設定を行いました。 #65 
付け焼き刃なのでコードの不備や抜けがありかもしれないです！確認お願いします🙇‍♂️