### PR TITLE
twitterシェアボタンの追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,6 @@ module ApplicationHelper
       },
       twitter: {
         card: 'summary_large_image',
-        site:,
       }
     }
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <script src="https://kit.fontawesome.com/20a1e3d994.js" crossorigin="anonymous"></script>
 
     <%= display_meta_tags(default_meta_tags) %>
     <%= csrf_meta_tags %>

--- a/app/views/quests/show.html.erb
+++ b/app/views/quests/show.html.erb
@@ -10,6 +10,11 @@
   <h3 class="sm:text-2xl text-base font-medium text-current mt-4 mb-3 drop-shadow-lg"><%= t('defaults.requester') %> : <%= @quest.user.name %></h3>
   <% if current_user.own?(@quest) && @quest.state == 'not_completed' %>
     <%= render 'edit_button', quest: @quest %>
+    <button class="bg-blue-400 hover:bg-blue-300 text-white rounded px-5 py-2" style="margin-left: 10px">
+      <%= link_to "https://twitter.com/share?url=#{ request.url }&text=討伐会を募集しました！%0a課題名: 【#{ @quest.title }】%0a&hashtags=CodeHunter", target: '_blank' do %>
+        <i class="fab fa-twitter" style='color: white;'></i>Twitterで募集する
+      <% end %>
+    </button>
   <% else %>
     <%= render 'join_button', quest: @quest if @quest.state == 'not_completed' %>
   <% end %>


### PR DESCRIPTION
# 概要 #67 
投稿詳細ボタンにtwitterシェアボタンを追加しました！
- 投稿主の場合、投稿詳細画面にtwitterシェアボタンの追加


↓クエスト詳細ページ
![1](https://user-images.githubusercontent.com/113349377/232452244-9355db2c-b307-4edd-b42c-a105f80eaaa2.png)
↓twitter
<img width="1366" alt="2" src="https://user-images.githubusercontent.com/113349377/232452327-b71d0df1-3717-46e6-98ea-d900cb49482b.png">

コードが雑なところがあるかもなのでリファクタリング可能な箇所等あればおっしゃってください！